### PR TITLE
[FIX] 마이페이지 리스트 조회 이슈 수정

### DIFF
--- a/src/components/mypage/MypageList.jsx
+++ b/src/components/mypage/MypageList.jsx
@@ -30,7 +30,7 @@ const TableBodyContent = (searchType, rowDatas) => {
 const ArticleRow = (rowDatas) =>
   rowDatas.map((rowData, index) => (
     <TableTR key={`ArticleRow_${rowData.boardId}_${index}`}>
-      <TableTextCenterTD>{rowData.boardId}</TableTextCenterTD>
+      <TableTextCenterTD>{rowData.boardType}</TableTextCenterTD>
       <TableTextLeftTD>
         <Link
           to={`/article/${rowData.articleId}`}
@@ -62,7 +62,7 @@ const ReplyRow = (rowDatas) =>
 const LikeRow = (rowDatas) =>
   rowDatas.map((rowData, index) => (
     <TableTR key={`LikeRow_${rowData.boardId}_${index}`}>
-      <TableTextCenterTD>{rowData.boardId}</TableTextCenterTD>
+      <TableTextCenterTD>{rowData.boardType}</TableTextCenterTD>
       <TableTextLeftTD>
         <Link
           to={`/article/${rowData.articleId}`}


### PR DESCRIPTION
마이페이지에서 리스트를 조회할 때 게시판을 숫자가 아닌 
게시판 이름으로 반영하기 위해 boardType 추가하였음.